### PR TITLE
Migración del código a python 3 y creación de la rama python3

### DIFF
--- a/Routines.py
+++ b/Routines.py
@@ -34,7 +34,7 @@ def CountingFunction(Text,Pattern):
     if type(Text) is not list and type(Text) is not np.ndarray and type(Text) is not str and type(Text):
         print("Bad usage of this function: CountingFunction(Arr,Pat) Arr: must be a list or an array or string, Pat: must be a string")
         return 
-    if type(Text) is str or type(Text):
+    if type(Text) is str:
         MyArray=np.array(StripPunc(Text).split(" "))
     if type(Text) is list:
         MyArray=np.array(Text)
@@ -97,6 +97,16 @@ def sumador(Dicc):
     total = {k:np.sum(v) for (k,v) in Dicc.items()}
     return total
 
+def contador_stemming(Texto, Diccionarios):
+    #Input y output igual a los de la función contador.
+    Texto_stem = [spanish_stemmer.stem(word) for word in Texto.split()]
+    
+    Dicc_stem = {}
+    for i in Diccionarios:
+        Dicc_stem[i] = [spanish_stemmer.stem(expr) for expr in Diccionarios[i]]
+
+    return contador(Texto_stem, Dicc_stem)
+
 #########
 
 if __name__ == '__main__':
@@ -130,3 +140,11 @@ if __name__ == '__main__':
     ResultadoTexto2=contador(Texto2.replace("a",Afects['Socioculturales'][4]),Afects)
     print("Conteo del texto 2: \n: ",ResultadoTexto2)
     print("Total del conteo del texto 2: \n",sumador(ResultadoTexto2))
+    
+    ResultadoTexto1Stem = contador_stemming(Texto1.replace("a",Afects['Proyecto de vida'][6]), Afects)
+    print('\n Con Stem: \n Texto 1: \n', ResultadoTexto1Stem)
+    print('Total: \n', sumador(ResultadoTexto1Stem))
+    
+    ResultadoTexto2Stem = contador_stemming(Texto2.replace("a",Afects['Socioculturales'][4]), Afects)
+    print('\n Texto 2: \n', ResultadoTexto2Stem)
+    print('Total: \n', sumador(ResultadoTexto2Stem))

--- a/Routines.py
+++ b/Routines.py
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# #Los strings en python 3+ son por defecto unicode. El encabezado uft y los prefijos u son redundantes para el programa. 
 
 import numpy as np
 
@@ -22,19 +22,19 @@ spanish_stemmer = SnowballStemmer('spanish')
 def PreparacionTexto(Texto,SignosPuntuacion,StopWords=stop_words,Stemmer=spanish_stemmer):
     StrippedText=StripPunc(Texto)
     tokenized_word=word_tokenize(StrippedText)
-    print tokenized_word
+    print(tokenized_word)
     filtered_words = [i for i in tokenized_word if i not in StopWords]
-    print filtered_words
+    print(filtered_words)
     stemmed_text = [Stemmer.stem(i) for i in filtered_words]
     print(stemmed_text)
 
 #########
 
 def CountingFunction(Text,Pattern):
-    if type(Text) is not list and type(Text) is not np.ndarray and type(Text) is not str and type(Text) is not unicode:
-        print "Bad usage of this function: CountingFunction(Arr,Pat) Arr: must be a list or an array or string, Pat: must be a string"
+    if type(Text) is not list and type(Text) is not np.ndarray and type(Text) is not str and type(Text):
+        print("Bad usage of this function: CountingFunction(Arr,Pat) Arr: must be a list or an array or string, Pat: must be a string")
         return 
-    if type(Text) is str or type(Text) is unicode:
+    if type(Text) is str or type(Text):
         MyArray=np.array(StripPunc(Text).split(" "))
     if type(Text) is list:
         MyArray=np.array(Text)
@@ -43,9 +43,9 @@ def CountingFunction(Text,Pattern):
     return np.count_nonzero(MyArray == Pattern)
 
 
-Texto1 = u"Muy lejos, más allá de las montañas de palabras, alejados de los países de las vocales y las consonantes, viven los textos simulados. Viven aislados en casas de letras, en la costa de la semántica, un gran océano de lenguas. Un riachuelo llamado Pons fluye por su pueblo y los abastece con las normas necesarias. Hablamos de un país paraisomático en el que a uno le caen pedazos de frases asadas en la boca. Ni siquiera los todopoderosos signos de puntuación dominan a los textos simulados; una vida, se puede decir, poco ortográfica. Pero un buen día, una pequeña línea de texto simulado, llamada Lorem Ipsum, decidió aventurarse y salir al vasto mundo de la gramática. El gran Oxmox le desanconsejó hacerlo, ya que esas tierras estaban llenas de comas malvadas, signos de interrogación salvajes y puntos y coma traicioneros, pero el texto simulado no se dejó atemorizar. Empacó sus siete versales, enfundó su inicial en el cinturón y se puso en camino. Cuando ya había escalado las primeras colinas de las montañas cursivas, se dio media vuelta para dirigir su mirada por última vez, hacia su ciudad natal Letralandia, el encabezamiento del pueblo Alfabeto y el subtítulo de su propia calle, la calle del renglón. Una pregunta retórica se le pasó por la mente y le puso melancólico, pero enseguida reemprendió su marcha. De nuevo en camino, se encontró con una copia. La copia advirtió al pequeño texto simulado de que en el lugar del que ella venía, la habían reescrito miles de veces y que todo lo que había quedado de su original era la palabra 'y', así que más le valía al pequeño texto simulado volver a su país, donde estaría mucho más seguro. Pero nada de lo dicho por la copia pudo convencerlo, de manera que al cabo de poco tiempo, unos pérfidos redactores publicitarios lo encontraron y emborracharon con Longe y Parole para llevárselo después a su agencia, donde abusaron de él para sus proyectos, una y otra vez. Y si aún no lo han reescrito, lo siguen utilizando hasta ahora.Muy lejos, más allá de las montañas de palabras, alejados de los países de las vocales y las consonantes, viven los textos simulados. Viven aislados en casas de letras, en la costa de la semántica, un gran océano de lenguas. Un riachuelo llamado Pons fluye por su pueblo y los abastece con las normas necesarias. Hablamos de un país paraisomático en el que a uno le caen pedazos de frases asadas en la boca. Ni siquiera los todopoderosos signos de puntuación dominan a los textos simulados; una vida, se puede decir, poco ortográfica. Pero un buen día, una pequeña línea de texto simulado, llamada Lorem Ipsum, decidió aventurarse y salir al vasto mundo de la gramática. El gran Oxmox le desanconsejó hacerlo, ya que esas tierras estaban llenas de comas malvadas, signos de interrogación salvajes y puntos y coma traicioneros, pero el texto simulado no se dejó atemorizar. Empacó sus siete versales, enfundó su"
+Texto1 = "Muy lejos, más allá de las montañas de palabras, alejados de los países de las vocales y las consonantes, viven los textos simulados. Viven aislados en casas de letras, en la costa de la semántica, un gran océano de lenguas. Un riachuelo llamado Pons fluye por su pueblo y los abastece con las normas necesarias. Hablamos de un país paraisomático en el que a uno le caen pedazos de frases asadas en la boca. Ni siquiera los todopoderosos signos de puntuación dominan a los textos simulados; una vida, se puede decir, poco ortográfica. Pero un buen día, una pequeña línea de texto simulado, llamada Lorem Ipsum, decidió aventurarse y salir al vasto mundo de la gramática. El gran Oxmox le desanconsejó hacerlo, ya que esas tierras estaban llenas de comas malvadas, signos de interrogación salvajes y puntos y coma traicioneros, pero el texto simulado no se dejó atemorizar. Empacó sus siete versales, enfundó su inicial en el cinturón y se puso en camino. Cuando ya había escalado las primeras colinas de las montañas cursivas, se dio media vuelta para dirigir su mirada por última vez, hacia su ciudad natal Letralandia, el encabezamiento del pueblo Alfabeto y el subtítulo de su propia calle, la calle del renglón. Una pregunta retórica se le pasó por la mente y le puso melancólico, pero enseguida reemprendió su marcha. De nuevo en camino, se encontró con una copia. La copia advirtió al pequeño texto simulado de que en el lugar del que ella venía, la habían reescrito miles de veces y que todo lo que había quedado de su original era la palabra 'y', así que más le valía al pequeño texto simulado volver a su país, donde estaría mucho más seguro. Pero nada de lo dicho por la copia pudo convencerlo, de manera que al cabo de poco tiempo, unos pérfidos redactores publicitarios lo encontraron y emborracharon con Longe y Parole para llevárselo después a su agencia, donde abusaron de él para sus proyectos, una y otra vez. Y si aún no lo han reescrito, lo siguen utilizando hasta ahora.Muy lejos, más allá de las montañas de palabras, alejados de los países de las vocales y las consonantes, viven los textos simulados. Viven aislados en casas de letras, en la costa de la semántica, un gran océano de lenguas. Un riachuelo llamado Pons fluye por su pueblo y los abastece con las normas necesarias. Hablamos de un país paraisomático en el que a uno le caen pedazos de frases asadas en la boca. Ni siquiera los todopoderosos signos de puntuación dominan a los textos simulados; una vida, se puede decir, poco ortográfica. Pero un buen día, una pequeña línea de texto simulado, llamada Lorem Ipsum, decidió aventurarse y salir al vasto mundo de la gramática. El gran Oxmox le desanconsejó hacerlo, ya que esas tierras estaban llenas de comas malvadas, signos de interrogación salvajes y puntos y coma traicioneros, pero el texto simulado no se dejó atemorizar. Empacó sus siete versales, enfundó su"
 
-Texto2 = u"Una mañana, tras un sueño intranquilo, Gregorio Samsa se despertó convertido en un monstruoso insecto. Estaba echado de espaldas sobre un duro caparazón y, al alzar la cabeza, vio su vientre convexo y oscuro, surcado por curvadas callosidades, sobre el que casi no se aguantaba la colcha, que estaba a punto de escurrirse hasta el suelo. Numerosas patas, penosamente delgadas en comparación con el grosor normal de sus piernas, se agitaban sin concierto. - ¿Qué me ha ocurrido? No estaba soñando. Su habitación, una habitación normal, aunque muy pequeña, tenía el aspecto habitual. Sobre la mesa había desparramado un muestrario de paños - Samsa era viajante de comercio-, y de la pared colgaba una estampa recientemente recortada de una revista ilustrada y puesta en un marco dorado. La estampa mostraba a una mujer tocada con un gorro de pieles, envuelta en una estola también de pieles, y que, muy erguida, esgrimía un amplio manguito, asimismo de piel, que ocultaba todo su antebrazo. Gregorio miró hacia la ventana; estaba nublado, y sobre el cinc del alféizar repiqueteaban las gotas de lluvia, lo que le hizo sentir una gran melancolía. «Bueno -pensó-; ¿y si siguiese durmiendo un rato y me olvidase de todas estas locuras?» Pero no era posible, pues Gregorio tenía la costumbre de dormir sobre el lado derecho, y su actual estado no le permitía adoptar tal postura. Por más que se esforzara volvía a quedar de espaldas. Intentó en vano esta operación numerosas veces; cerró los ojos para no tener que ver aquella confusa agitación de patas, que no cesó hasta que notó en el costado un dolor leve y punzante, un dolor jamás sentido hasta entonces. - ¡Qué cansada es la profesión que he elegido! -se dijo-. Siempre de viaje. Las preocupaciones son mucho mayores cuando se trabaja fuera, por no hablar de las molestias propias de los viajes: estar pendiente de los enlaces de los trenes; la comida mala, irregular; relaciones que cambian constantemente, que nunca llegan a ser verdaderamente cordiales, y en las que no tienen cabida los sentimientos. ¡Al diablo con todo! Sintió en el vientre una ligera picazón. Lentamente, se estiró sobre la espalda en dirección a la cabecera de la cama, para poder alzar mejor la cabeza. Vio que el sitio que le picaba estaba cubierto de extraños untitos blancos. Intentó rascarse con una pata; pero tuvo que retirarla inmediatamente, pues el roce le producía escalofríos. Una mañana, tras un sueño intranquilo, Gregorio Samsa se despertó convertido en un monstruoso insecto. Estaba echado de espaldas sobre un duro caparazón y, al alzar la cabeza, vio su vientre convexo y oscuro, surcado por curvadas callosidades, sobre el que casi no se aguantaba la colcha, que estaba a punto de escurrirse hasta el suelo. Numerosas patas, penosamente delgadas en comparación con el grosor normal de sus piernas, se agitaban sin concierto. - ¿Qué me ha ocurrido? No estaba soñando. Su habitación, una habitación normal, aunque muy pequeña, tenía el aspecto habitual. Sobre la mesa había"
+Texto2 = "Una mañana, tras un sueño intranquilo, Gregorio Samsa se despertó convertido en un monstruoso insecto. Estaba echado de espaldas sobre un duro caparazón y, al alzar la cabeza, vio su vientre convexo y oscuro, surcado por curvadas callosidades, sobre el que casi no se aguantaba la colcha, que estaba a punto de escurrirse hasta el suelo. Numerosas patas, penosamente delgadas en comparación con el grosor normal de sus piernas, se agitaban sin concierto. - ¿Qué me ha ocurrido? No estaba soñando. Su habitación, una habitación normal, aunque muy pequeña, tenía el aspecto habitual. Sobre la mesa había desparramado un muestrario de paños - Samsa era viajante de comercio-, y de la pared colgaba una estampa recientemente recortada de una revista ilustrada y puesta en un marco dorado. La estampa mostraba a una mujer tocada con un gorro de pieles, envuelta en una estola también de pieles, y que, muy erguida, esgrimía un amplio manguito, asimismo de piel, que ocultaba todo su antebrazo. Gregorio miró hacia la ventana; estaba nublado, y sobre el cinc del alféizar repiqueteaban las gotas de lluvia, lo que le hizo sentir una gran melancolía. «Bueno -pensó-; ¿y si siguiese durmiendo un rato y me olvidase de todas estas locuras?» Pero no era posible, pues Gregorio tenía la costumbre de dormir sobre el lado derecho, y su actual estado no le permitía adoptar tal postura. Por más que se esforzara volvía a quedar de espaldas. Intentó en vano esta operación numerosas veces; cerró los ojos para no tener que ver aquella confusa agitación de patas, que no cesó hasta que notó en el costado un dolor leve y punzante, un dolor jamás sentido hasta entonces. - ¡Qué cansada es la profesión que he elegido! -se dijo-. Siempre de viaje. Las preocupaciones son mucho mayores cuando se trabaja fuera, por no hablar de las molestias propias de los viajes: estar pendiente de los enlaces de los trenes; la comida mala, irregular; relaciones que cambian constantemente, que nunca llegan a ser verdaderamente cordiales, y en las que no tienen cabida los sentimientos. ¡Al diablo con todo! Sintió en el vientre una ligera picazón. Lentamente, se estiró sobre la espalda en dirección a la cabecera de la cama, para poder alzar mejor la cabeza. Vio que el sitio que le picaba estaba cubierto de extraños untitos blancos. Intentó rascarse con una pata; pero tuvo que retirarla inmediatamente, pues el roce le producía escalofríos. Una mañana, tras un sueño intranquilo, Gregorio Samsa se despertó convertido en un monstruoso insecto. Estaba echado de espaldas sobre un duro caparazón y, al alzar la cabeza, vio su vientre convexo y oscuro, surcado por curvadas callosidades, sobre el que casi no se aguantaba la colcha, que estaba a punto de escurrirse hasta el suelo. Numerosas patas, penosamente delgadas en comparación con el grosor normal de sus piernas, se agitaban sin concierto. - ¿Qué me ha ocurrido? No estaba soñando. Su habitación, una habitación normal, aunque muy pequeña, tenía el aspecto habitual. Sobre la mesa había"
 
 #Construccion de Diccionarios
 
@@ -53,18 +53,18 @@ import pandas
 
 def DictsBuild(CSVFile,Debug=False):
     #df = pandas.read_csv('DiccionariosVersionDic1_2020.csv')
-    df = pandas.read_csv(CSVFile, encoding="utf-8")
+    df = pandas.read_csv(CSVFile)
 
     ListaDeAfectaciones = [7,8,9,10,11,13,14,15,16,17,18,19,20]
     Afectaciones = {}
-    StringDeUso=u'Sinónimos-Palabras'
+    StringDeUso='Sinónimos-Palabras'
     if Debug:
-        print StringDeUso
+        print(StringDeUso)
     for i in ListaDeAfectaciones:
         ListaDeAfects=df[StringDeUso][i].replace(", ", ",").split(",")
         Afectaciones[df['Nodos'][i]] = [x.strip() for x in ListaDeAfects if x]
     if Debug:
-        print Afectaciones
+        print(Afectaciones)
     return Afectaciones
 
 #Contadores de palabras
@@ -100,8 +100,8 @@ if __name__ == '__main__':
     if ElEjemploMasSencillo:
         Textos=[Texto1,Texto2]
 
-        Dict1=[u"casa",u"letra",u"rato",u"ojos"]
-        Dict2=[u"signos",u"concierto",u"grosor",u"diablo",u"patas",u"vida"]
+        Dict1=["casa","letra","rato","ojos"]
+        Dict2=["signos","concierto","grosor","diablo","patas","vida"]
         Dicts=[Dict1,Dict2]
 
         Freqs=[]
@@ -113,11 +113,11 @@ if __name__ == '__main__':
                     CurrentFreq.append(CountingFunction(i,k))
                 Freqs.append(CurrentFreq)
 
-        print Freqs
+        print(Freqs)
 
 
     Afects=DictsBuild('DiccionariosVersionDic1_2020.csv',Debug=False)
-    ResultadoTexto1=contador(Texto1.replace(u"a",Afects[u'Proyecto de vida'][6]),Afects)
-    print ResultadoTexto1
-    ResultadoTexto2=contador(Texto2.replace(u"a",Afects[u'Socioculturales'][4]),Afects)
-    print ResultadoTexto2
+    ResultadoTexto1=contador(Texto1.replace("a",Afects['Proyecto de vida'][6]),Afects)
+    print(ResultadoTexto1)
+    ResultadoTexto2=contador(Texto2.replace("a",Afects['Socioculturales'][4]),Afects)
+    print(ResultadoTexto2)

--- a/Routines.py
+++ b/Routines.py
@@ -91,6 +91,12 @@ def getText(filename):#
         fullText.append(para.text)
     return '\n'.join(fullText)
 
+def sumador(Dicc):      
+    #INPUT: Recibe el diccionario que devuelve contador
+    #OUTPUT: diccionario con el total de conteos por afectación. 
+    total = {k:np.sum(v) for (k,v) in Dicc.items()}
+    return total
+
 #########
 
 if __name__ == '__main__':
@@ -118,6 +124,9 @@ if __name__ == '__main__':
 
     Afects=DictsBuild('DiccionariosVersionDic1_2020.csv',Debug=False)
     ResultadoTexto1=contador(Texto1.replace("a",Afects['Proyecto de vida'][6]),Afects)
-    print(ResultadoTexto1)
+    print("Conteo del texto 1: \n", ResultadoTexto1)
+    print("Total del conteo texto 1: \n", sumador(ResultadoTexto1),"\n")
+
     ResultadoTexto2=contador(Texto2.replace("a",Afects['Socioculturales'][4]),Afects)
-    print(ResultadoTexto2)
+    print("Conteo del texto 2: \n: ",ResultadoTexto2)
+    print("Total del conteo del texto 2: \n",sumador(ResultadoTexto2))


### PR DESCRIPTION
Se incluyeron los paréntesis en los prints y se quitaron los prefijos u, ya que son redundantes en python 3 o superior (Por defecto todos los strings definidos son unicode).